### PR TITLE
Changed implementations to accept to access the value just like the dict objects

### DIFF
--- a/constants_manager/constants_manager.py
+++ b/constants_manager/constants_manager.py
@@ -10,18 +10,12 @@ class ConstantsManager():
         self.config = configparser.RawConfigParser()
         self.config.optionxform = str
         self.config.read(config_file_name)
-        self.constants_name = constants_name
+        self.environment = 'DEFAULT'
+        if constants_name in os.environ:
+            self.environment = os.environ[constants_name]
 
     def __getitem__(self, key):
         return self.get(key)
 
-    def __get_environment(self):
-        __env_default = 'DEFAULT'
-        __constants_name = self.constants_name
-        __env = os.environ[__constants_name] if __constants_name in os.environ else __env_default
-        return __env
-
     def get(self, key):
-        __env = self.__get_environment()
-        __val = self.config.get(__env, key)
-        return __val
+        return self.config.get(self.environment, key)

--- a/constants_manager/constants_manager.py
+++ b/constants_manager/constants_manager.py
@@ -10,6 +10,9 @@ class ConstantsManager():
         self.config_file_name = config_file_name
         self.constants_name = constants_name
 
+    def __getitem__(self, key):
+        return self.get(key)
+
     def __get_environment(self):
         __env_default = 'DEFAULT'
         __constants_name = self.constants_name

--- a/constants_manager/constants_manager.py
+++ b/constants_manager/constants_manager.py
@@ -7,7 +7,9 @@ import os
 
 class ConstantsManager():
     def __init__(self, config_file_name='constants.ini', constants_name='ENV'):
-        self.config_file_name = config_file_name
+        self.config = configparser.RawConfigParser()
+        self.config.optionxform = str
+        self.config.read(config_file_name)
         self.constants_name = constants_name
 
     def __getitem__(self, key):
@@ -20,9 +22,6 @@ class ConstantsManager():
         return __env
 
     def get(self, key):
-        config = configparser.RawConfigParser()
-        config.optionxform = str
-        config.read(self.config_file_name)
         __env = self.__get_environment()
-        __val = config.get(__env, key)
+        __val = self.config.get(__env, key)
         return __val

--- a/test_constants_manager.py
+++ b/test_constants_manager.py
@@ -9,6 +9,7 @@ class TestConstantsManager():
 
         consts = ConstantsManager()
         assert __expected == consts.get('val_only_default')
+        assert __expected == consts['val_only_default']
 
     def test_get_section_value(self):
         __expected = 'val_only_dev'
@@ -16,6 +17,7 @@ class TestConstantsManager():
         os.environ["ENV"] = 'dev'
         consts = ConstantsManager()
         assert __expected == consts.get('val_only_dev')
+        assert __expected == consts['val_only_dev']
 
     def test_get_default_value_witout_section_value(self):
         __expected = 'val_only_default'
@@ -23,6 +25,7 @@ class TestConstantsManager():
         os.environ["ENV"] = 'dev'
         consts = ConstantsManager()
         assert __expected == consts.get('val_only_default')
+        assert __expected == consts['val_only_default']
 
     def test_change_os_environment(self):
         __expected = 'val_only_default'
@@ -30,6 +33,7 @@ class TestConstantsManager():
         os.environ["ENV_DUMMY"] = 'dev'
         consts = ConstantsManager(constants_name='ENV_DUMMY')
         assert __expected == consts.get('val_only_default')
+        assert __expected == consts['val_only_default']
 
     def test_using_not_exists_os_environment(self):
         __expected = 'val_only_default'
@@ -37,6 +41,7 @@ class TestConstantsManager():
         os.environ["ENV_DUMMY"] = 'dev'
         consts = ConstantsManager()
         assert __expected == consts.get('val_only_default')
+        assert __expected == consts['val_only_default']
 
     def test_using_not_exists_os_environment_and_not_find_key(self):
         os.environ["ENV_DUMMY"] = 'dev'

--- a/test_constants_manager.py
+++ b/test_constants_manager.py
@@ -1,4 +1,8 @@
 from constants_manager.constants_manager import ConstantsManager
+try:
+    from ConfigParser import NoOptionError
+except ImportError:
+    from configparser import NoOptionError
 import os
 import pytest
 
@@ -46,5 +50,5 @@ class TestConstantsManager():
     def test_using_not_exists_os_environment_and_not_find_key(self):
         os.environ["ENV_DUMMY"] = 'dev'
         consts = ConstantsManager(constants_name='DUMMY')
-        with pytest.raises(Exception):
+        with pytest.raises(NoOptionError):
             consts.get('val_only_dev')

--- a/test_constants_manager.py
+++ b/test_constants_manager.py
@@ -1,5 +1,6 @@
 from constants_manager.constants_manager import ConstantsManager
 import os
+import pytest
 
 
 class TestConstantsManager():
@@ -40,6 +41,5 @@ class TestConstantsManager():
     def test_using_not_exists_os_environment_and_not_find_key(self):
         os.environ["ENV_DUMMY"] = 'dev'
         consts = ConstantsManager(constants_name='DUMMY')
-        import pytest
         with pytest.raises(Exception):
             consts.get('val_only_dev')


### PR DESCRIPTION
#### Change the implementations
- Added a new interface to access the value (like `consts['val_only_default']`).
- Moved processes (getting a environment and parsing the ini file) from each method to constructor.
  - I guess it was not good way to parse ini file and determine environment per getting the values.
#### Change the tests
- Moved `import pytest` to top of the test file.
  - I didn't know why it was specified in the method...
- Changed expected exception class from `Exception` to `configparser`.`NoOptionError` to be more explicit.
- Added tests to check a additional interface (like `consts['val_only_default']`).
